### PR TITLE
Add Trove classifier for Python 3.13

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -495,6 +495,7 @@ sorted_classifiers: List[str] = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: Implementation",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: IronPython",


### PR DESCRIPTION
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

<!-- Replace the following with the name of your classifier -->
* ``Programming Language :: Python :: 3.13``

## Why do you want to add this classifier?

Python 3.12 is now in the release candidate stage; CPython HEAD is Python 3.12.

See last year's PR: #107

A